### PR TITLE
feature/KA-39 Enable federation on provider-side

### DIFF
--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -1,0 +1,27 @@
+name: Integration Tests
+
+on: workflow_dispatch
+
+jobs:
+  run_integration_test:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Execute Integration Tests
+        uses: matt-ball/newman-action@master
+        with:
+          reporters: '["junit"]'
+          collection: cx_ka_pilot.postman_collection.json
+          environment: cx_ka_pilot.integration.postman_environment.json
+          folder: '["Integration Tests"]' # See https://github.com/matt-ball/newman-action/issues/50
+          envVar: '[{ "key": "oemPassword", "value": "${{ secrets.ORG_KNOWLEDGE_PASSWORD }}" }, { "key": "oemEdcApiKey", "value": "${{ secrets.ORG_KNOWLEDGE_API_KEY }}" }]'
+      - if: always()
+        name: Test Report
+        uses: dorny/test-reporter@v1
+        with:
+          name: Test Report Postman
+          path: 'newman/newman-run-report-*.xml'
+          reporter: java-junit

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentConfig.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentConfig.java
@@ -18,9 +18,8 @@ import java.util.Map;
 public class AgentConfig {
 
     public static String DEFAULT_ASSET_PROPERTY = "cx.agent.asset.default";
-    public static String DEFAULT_ASSET_NAME = "urn:graph:cx:Dataspace";
+    public static String DEFAULT_ASSET_NAME = "urn:x-arq:DefaultGraph";
     public static String ASSET_FILE_PROPERTY = "cx.agent.asset.file";
-    public static String DEFAULT_ASSET_FILE = "dataspace.ttl";
     public static String ACCESS_POINT_PROPERTY = "cx.agent.accesspoint.name";
     public static String VERBOSE_PROPERTY = "cx.agent.sparql.verbose";
     public static boolean DEFAULT_VERBOSE_PROPERTY = false;
@@ -63,7 +62,7 @@ public class AgentConfig {
      * @return initial file to load
      */
     public String getAssetFile() {
-        return config.getString(ASSET_FILE_PROPERTY, DEFAULT_ASSET_FILE);
+        return config.getString(ASSET_FILE_PROPERTY,null);
     }
 
     /**

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentSinkFactory.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentSinkFactory.java
@@ -54,7 +54,7 @@ public class AgentSinkFactory extends org.eclipse.dataspaceconnector.dataplane.h
     @Override
     public DataSink createSink(DataFlowRequest request) {
         DataSink sink=super.createSink(request);
-        monitor.debug(String.format("Created a new agent sink %s for destination %s and params %s",sink,request.getDestinationDataAddress().getType(),supplier.apply(request).toRequest()));
+        monitor.debug(String.format("Created a new agent sink %s for destination type %s",sink,request.getDestinationDataAddress().getType()));
         return sink;
 
     }

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentSource.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentSource.java
@@ -1,0 +1,209 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package io.catenax.knowledge.dataspace.edc;
+
+import dev.failsafe.RetryPolicy;
+import io.catenax.knowledge.dataspace.edc.sparql.SparqlQueryProcessor;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+import org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpRequestParams;
+import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.stream.Stream;
+
+import static dev.failsafe.Failsafe.with;
+import static java.lang.String.format;
+
+/**
+ * An agent-enabled http-transfer source
+ * there are two modes of operation: Routing transfer and
+ * calling a single (in the future: several) graph endpoint
+ * (in which case we rather need to
+ * invoke the surrounding plane sparql engine to
+ * perform some joins/pre and postprocessing and event
+ * further delegations) and that engine will in turn
+ * delegate to the final endpoint (for which we
+ * replace any "GRAPH" occurences with "SERVICE" references
+ * in the processor)
+ * TODO generalize to shield several endpoints/assets
+ */
+public class AgentSource implements DataSource {
+    protected String name;
+    protected HttpRequestParams params;
+    protected String requestId;
+    protected RetryPolicy<Object> retryPolicy;
+    protected OkHttpClient httpClient;
+    protected boolean isTransfer;
+    protected SparqlQueryProcessor processor;
+    protected SkillStore skillStore;
+
+    protected DataFlowRequest request;
+
+    /**
+     * creates new agent source
+     */
+    public AgentSource() {
+    }
+
+    @Override
+    public Stream<Part> openPartStream() {
+        return Stream.of(getPart());
+    }
+
+    /**
+     * main logic calling the agent
+     * @return the result as a named byte array
+     */
+    protected AgentPart getPart() {
+        if(!isTransfer) {
+            String skill=null;
+            String graph=null;
+            String asset= request.getSourceDataAddress().getProperties().get("asset:prop:id");
+            if(asset!=null && asset.length() > 0) {
+                Matcher graphMatcher=AgentExtension.GRAPH_PATTERN.matcher(asset);
+                if(graphMatcher.matches()) {
+                    graph=asset;
+                }
+                Matcher skillMatcher=SkillStore.SKILL_PATTERN.matcher(asset);
+                if(skillMatcher.matches()) {
+                    skill=asset;
+                }
+            }
+            try (Response response = processor.execute(params.toRequest(),skill,graph)) {
+                return getPart(response);
+            } catch (IOException e) {
+                throw new EdcException(e);
+            }
+        } else {
+            try (var response = with(retryPolicy).get(() -> httpClient.newCall(params.toRequest()).execute())) {
+                return getPart(response);
+            } catch (IOException e) {
+                throw new EdcException(e);
+            }
+        }
+    }
+
+    /**
+     * helper to perform the body processing
+     * @param response a given response from the agent
+     * @return body as named byte array
+     * @throws IOException in case anything goes wrong
+     * TODO proper status handling in case of expected failures
+     */
+    protected AgentPart getPart(Response response) throws IOException {
+        var body = response.body();
+        var stringBody = body != null ? body.string() : null;
+        if (stringBody == null) {
+            throw new EdcException(format("Received empty response body transferring HTTP data for request %s: %s", requestId, response.code()));
+        }
+        if (response.isSuccessful()) {
+            return new AgentPart(name, stringBody.getBytes());
+        } else {
+            throw new EdcException(format("Received code transferring HTTP data for request %s: %s - %s. %s", requestId, response.code(), response.message(), stringBody));
+        }
+    }
+
+    /**
+     * the agent source builder
+     */
+    public static class Builder {
+        protected final AgentSource dataSource;
+
+        public static AgentSource.Builder newInstance() {
+            return new AgentSource.Builder();
+        }
+
+        public AgentSource.Builder params(HttpRequestParams params) {
+            dataSource.params = params;
+            return this;
+        }
+
+        public AgentSource.Builder name(String name) {
+            dataSource.name = name;
+            return this;
+        }
+
+        public AgentSource.Builder requestId(String requestId) {
+            dataSource.requestId = requestId;
+            return this;
+        }
+
+        public AgentSource.Builder retryPolicy(RetryPolicy<Object> retryPolicy) {
+            dataSource.retryPolicy = retryPolicy;
+            return this;
+        }
+
+        public AgentSource.Builder httpClient(OkHttpClient httpClient) {
+            dataSource.httpClient = httpClient;
+            return this;
+        }
+
+        public AgentSource.Builder isTransfer(boolean isTransfer) {
+            dataSource.isTransfer=isTransfer;
+            return this;
+        }
+
+        public AgentSource.Builder processor(SparqlQueryProcessor processor) {
+            dataSource.processor=processor;
+            return this;
+        }
+
+        public AgentSource.Builder skillStore(SkillStore skillStore) {
+            dataSource.skillStore=skillStore;
+            return this;
+        }
+
+        public AgentSource.Builder request(DataFlowRequest request) {
+            dataSource.request=request;
+            return this;
+        }
+
+        public AgentSource build() {
+            Objects.requireNonNull(dataSource.requestId, "requestId");
+            Objects.requireNonNull(dataSource.httpClient, "httpClient");
+            Objects.requireNonNull(dataSource.retryPolicy, "retryPolicy");
+            return dataSource;
+        }
+
+        public Builder() {
+            dataSource = new AgentSource();
+        }
+    }
+
+    private static class AgentPart implements Part {
+        private final String name;
+        private final byte[] content;
+
+        AgentPart(String name, byte[] content) {
+            this.name = name;
+            this.content = content;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public long size() {
+            return content.length;
+        }
+
+        @Override
+        public InputStream openStream() {
+            return new ByteArrayInputStream(content);
+        }
+
+    }
+}

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentSourceFactory.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/AgentSourceFactory.java
@@ -3,15 +3,15 @@
 // See copyright notice in the top folder
 // See authors file in the top folder
 // See license file in the top folder
+//
 package io.catenax.knowledge.dataspace.edc;
 
+import io.catenax.knowledge.dataspace.edc.sparql.SparqlQueryProcessor;
 import okhttp3.OkHttpClient;
-import org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpDataSource;
-import org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpRequestParamsSupplier;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.security.Vault;
 import dev.failsafe.RetryPolicy;
+import org.eclipse.dataspaceconnector.spi.types.domain.HttpDataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 
 /**
@@ -19,19 +19,28 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
  */
 public class AgentSourceFactory extends org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpDataSourceFactory {
 
-    final HttpRequestParamsSupplier supplier;
+    final AgentSourceRequestParamsSupplier supplier;
     final Monitor monitor;
+    final OkHttpClient httpClient;
+    final RetryPolicy<Object> retryPolicy;
+    final SparqlQueryProcessor processor;
+    final SkillStore skillStore;
 
     /**
      * create a new agent source factory
      * @param httpClient http outgoing system
-     * @param retryPolicy a retry ppolicy to use
-     * @param supplier a parameter supplier hellper
+     * @param retryPolicy a retry policy to use
+     * @param supplier a parameter supplier helper
+     * @param skillStore store for skills
      */
-    public AgentSourceFactory(OkHttpClient httpClient, RetryPolicy<Object> retryPolicy, HttpRequestParamsSupplier supplier, Monitor monitor) {
+    public AgentSourceFactory(OkHttpClient httpClient, RetryPolicy<Object> retryPolicy, AgentSourceRequestParamsSupplier supplier, Monitor monitor, SparqlQueryProcessor processor, SkillStore skillStore) {
         super(httpClient,retryPolicy,supplier);
         this.supplier=supplier;
         this.monitor=monitor;
+        this.httpClient=httpClient;
+        this.retryPolicy=retryPolicy;
+        this.skillStore=skillStore;
+        this.processor=processor;
     }
 
     /**
@@ -45,14 +54,43 @@ public class AgentSourceFactory extends org.eclipse.dataspaceconnector.dataplane
     }
 
     /**
-     * soon, we will create a special source tied to fuseki
+     * depending on the transfer mode,  choose to manipulate the
+     * target address.
      * @param request incoming agent protocol request
      * @return new data source
      */
     @Override
     public DataSource createSource(DataFlowRequest request) {
-        HttpDataSource dataSource=(HttpDataSource) super.createSource(request);
-        monitor.debug(String.format("Created a new agent source %s for destination type %s and params %s",dataSource,request.getDestinationDataAddress().getType(),supplier.apply(request).toRequest()));
+        boolean isTransfer=isTransferRequest(request);
+        var dataAddress = HttpDataAddress.Builder.newInstance()
+                .copyFrom(request.getSourceDataAddress())
+                .build();
+        AgentSource dataSource= AgentSource.Builder.newInstance()
+                .httpClient(httpClient)
+                .requestId(request.getId())
+                .name(dataAddress.getName())
+                .params(supplier.apply(request))
+                .retryPolicy(retryPolicy)
+                .isTransfer(isTransfer)
+                .skillStore(skillStore)
+                .processor(processor)
+                .request(request)
+                .build();
+        monitor.debug(String.format("Created a new agent source %s in transfer mode %b for destination type %s",
+                dataSource,isTransfer,
+                request.getDestinationDataAddress().getType()));
         return dataSource;
+    }
+
+    /**
+     * a check that distinguishes between http transfer
+     * and http data requests
+     * @param request incoming data flow request
+     * @return flag indicating whether its a transfer or protocol request
+     * TODO find a better heuristic as the endpoint may change
+     */
+    public static boolean isTransferRequest(DataFlowRequest request) {
+        return request.getSourceDataAddress().getProperties().getOrDefault("baseUrl", "").
+                contains("api/public");
     }
 }

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/SkillStore.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/SkillStore.java
@@ -1,0 +1,71 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package io.catenax.knowledge.dataspace.edc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * An in-memory store for local skills
+ */
+public class SkillStore {
+
+    // temporary local skill store
+    final protected Map<String,String> skills=new HashMap<>();
+
+    public static Pattern SKILL_PATTERN=Pattern.compile("((?<url>[^#]+)#)?(?<skill>(urn:(cx|artifact):)?([Ss])kill:.*)");
+
+    /**
+     * create the store
+     */
+    public SkillStore() {
+    }
+
+    /**
+     * match a given asset
+     * @param key asset name
+     * @return matcher
+     */
+    public Matcher matchSkill(String key) {
+        return SKILL_PATTERN.matcher(key);
+    }
+
+    /**
+     * check a given asset for being a skill
+     * @param key asset name
+     * @return whether the asset encodes a skill
+     */
+    public boolean isSkill(String key) {
+        return matchSkill(key).matches();
+    }
+
+    /**
+     * register a skill
+     * @param key asset name
+     * @param skill skill text
+     * @return old skill text, if one was registered
+     */
+    public String put(String key, String skill) {
+        return skills.put(key,skill);
+    }
+
+    /**
+     * return the stored skill text
+     * @param key asset name
+     * @return optional skill text if registered
+     */
+    public Optional<String> get(String key) {
+        if(!skills.containsKey(key)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(skills.get(key));
+        }
+    }
+}

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpResponseAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpResponseAdapter.java
@@ -21,13 +21,13 @@ import java.util.Optional;
 /**
  * wraps OkHttp Response to java.net.http version
  */
-public class HttpResponseWrapper implements HttpResponse<InputStream> {
+public class HttpResponseAdapter implements HttpResponse<InputStream> {
 
     Response delegate;
     HttpHeaders headers;
     HttpRequest request;
 
-    public HttpResponseWrapper(Response delegate, HttpRequest request) {
+    public HttpResponseAdapter(Response delegate, HttpRequest request) {
         this.delegate=delegate;
         this.request=request;
         headers=HttpHeaders.of(delegate.headers().toMultimap(), (key,value)->true);

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpServletContextAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpServletContextAdapter.java
@@ -1,0 +1,323 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package io.catenax.knowledge.dataspace.edc.http;
+
+import okhttp3.Request;
+
+import javax.servlet.*;
+import javax.servlet.descriptor.JspConfigDescriptor;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+
+/**
+ * Servlet context adapter which hides a mock okhttp request
+ */
+public class HttpServletContextAdapter implements ServletContext {
+
+    Request request;
+    protected final Map<String, Object> attributes = new HashMap<>();
+    public HttpServletContextAdapter(Request request) {
+        this.request=request;
+    }
+
+    @Override
+    public String getContextPath() {
+        return "";
+    }
+
+    @Override
+    public ServletContext getContext(String uripath) {
+        return this;
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getEffectiveMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getEffectiveMinorVersion() {
+        return 1;
+    }
+
+    @Override
+    public String getMimeType(String file) {
+        return null;
+    }
+
+    @Override
+    public Set<String> getResourcePaths(String path) {
+        return null;
+    }
+
+    @Override
+    public URL getResource(String path) throws MalformedURLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String path) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getNamedDispatcher(String name) {
+        return null;
+    }
+
+    @Override
+    public Servlet getServlet(String name) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public Enumeration<Servlet> getServlets() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getServletNames() {
+        return null;
+    }
+
+    @Override
+    public void log(String msg) {
+
+    }
+
+    @Override
+    public void log(Exception exception, String msg) {
+
+    }
+
+    @Override
+    public void log(String message, Throwable throwable) {
+
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        return null;
+    }
+
+    @Override
+    public String getServerInfo() {
+        return null;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        return null;
+    }
+
+    @Override
+    public boolean setInitParameter(String name, String value) {
+        return false;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return Collections.enumeration(attributes.keySet());
+    }
+
+    @Override
+    public void setAttribute(String name, Object object) {
+        attributes.put(name,object);
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        attributes.remove(name);
+    }
+
+    @Override
+    public String getServletContextName() {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String servletName, String className) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String servletName, Servlet servlet) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addJspFile(String servletName, String jspFile) {
+        return null;
+    }
+
+    @Override
+    public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration getServletRegistration(String servletName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends ServletRegistration> getServletRegistrations() {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String filterName, String className) {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String filterName, Filter filter) {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
+        return null;
+    }
+
+    @Override
+    public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration getFilterRegistration(String filterName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+        return null;
+    }
+
+    @Override
+    public SessionCookieConfig getSessionCookieConfig() {
+        return null;
+    }
+
+    @Override
+    public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {
+
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+        return null;
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+        return null;
+    }
+
+    @Override
+    public void addListener(String className) {
+
+    }
+
+    @Override
+    public <T extends EventListener> void addListener(T t) {
+
+    }
+
+    @Override
+    public void addListener(Class<? extends EventListener> listenerClass) {
+
+    }
+
+    @Override
+    public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public JspConfigDescriptor getJspConfigDescriptor() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+    @Override
+    public void declareRoles(String... roleNames) {
+
+    }
+
+    @Override
+    public String getVirtualServerName() {
+        return null;
+    }
+
+    @Override
+    public int getSessionTimeout() {
+        return 0;
+    }
+
+    @Override
+    public void setSessionTimeout(int sessionTimeout) {
+
+    }
+
+    @Override
+    public String getRequestCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setRequestCharacterEncoding(String encoding) {
+
+    }
+
+    @Override
+    public String getResponseCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setResponseCharacterEncoding(String encoding) {
+
+    }
+}

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpServletRequestAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpServletRequestAdapter.java
@@ -1,0 +1,390 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package io.catenax.knowledge.dataspace.edc.http;
+
+import okhttp3.Request;
+import okio.*;
+
+import javax.servlet.*;
+import javax.servlet.http.*;
+import java.io.*;
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Wraps an ok Request into a javax servlet request
+ */
+public class HttpServletRequestAdapter implements HttpServletRequest {
+
+    protected final Request request;
+    protected final ServletContext context;
+
+    public HttpServletRequestAdapter(Request request, ServletContext context) {
+        this.request=request;
+        this.context=context;
+    }
+
+    @Override
+    public String getAuthType() {
+        return null;
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return new Cookie[0];
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return request.header(name);
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        return Collections.enumeration(request.headers().values(name));
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return Collections.enumeration(request.headers().names());
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        return Integer.parseInt(request.header(name));
+    }
+
+    @Override
+    public String getMethod() {
+        return request.method();
+    }
+
+    @Override
+    public String getPathInfo() {
+        return request.url().encodedPath();
+    }
+
+    @Override
+    public String getPathTranslated() {
+        return request.url().encodedPath();
+    }
+
+    @Override
+    public String getContextPath() {
+        return request.url().encodedPath();
+    }
+
+    @Override
+    public String getQueryString() {
+        return request.url().query();
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return null;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return false;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        return null;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return request.url().uri().toString();
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        return new StringBuffer(request.url().url().toString());
+    }
+
+    @Override
+    public String getServletPath() {
+        return "";
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return null;
+    }
+
+    @Override
+    public String changeSessionId() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        return false;
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+
+    }
+
+    @Override
+    public void logout() throws ServletException {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return List.of();
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return context.getAttribute(name);
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return context.getAttributeNames();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+
+    }
+
+    @Override
+    public int getContentLength() {
+        try {
+            return (int) request.body().contentLength();
+        } catch(IOException e) {
+            return -1;
+        }
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        try {
+            return request.body().contentLength();
+        } catch(IOException e) {
+            return -1L;
+        }
+    }
+
+    @Override
+    public String getContentType() {
+        return request.body().contentType().toString();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        Buffer buffer=new Buffer();
+        request.body().writeTo(buffer);
+        ByteArrayInputStream bais=new ByteArrayInputStream(buffer.readByteArray());
+        return new ServletInputStreamDelegator(bais);
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return request.url().queryParameter(name);
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return Collections.enumeration(request.url().queryParameterNames());
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return request.url().queryParameterValues(name).toArray(new String[0]);
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        Map<String,String[]> parameterMap=new HashMap<>();
+        for (String queryParameterName : request.url().queryParameterNames()) {
+            parameterMap.put(queryParameterName,getParameterValues(queryParameterName));
+        }
+        return parameterMap;
+    }
+
+    @Override
+    public String getProtocol() {
+        return request.url().isHttps() ? "HTTPS" : "HTTP";
+    }
+
+    @Override
+    public String getScheme() {
+        return request.url().scheme();
+    }
+
+    @Override
+    public String getServerName() {
+        return request.url().host();
+    }
+
+    @Override
+    public int getServerPort() {
+        return request.url().port();
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return new BufferedReader(new StringReader(request.body().toString()));
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return request.url().fragment();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return request.url().host();
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+        context.setAttribute(name,o);
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        context.removeAttribute(name);
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        return null;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        return null;
+    }
+
+    @Override
+    public int getRemotePort() {
+        return request.url().port();
+    }
+
+    @Override
+    public String getLocalName() {
+        return "";
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return "";
+    }
+
+    @Override
+    public int getLocalPort() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return context;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
+    }
+}

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpServletResponseAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/HttpServletResponseAdapter.java
@@ -1,0 +1,224 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package io.catenax.knowledge.dataspace.edc.http;
+
+import okhttp3.*;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
+
+/**
+ * builds a ok response from an in-memory servlet response implementation
+ */
+public class HttpServletResponseAdapter implements HttpServletResponse {
+
+    Response.Builder builder=new Response.Builder();
+    ByteArrayOutputStream bos=new ByteArrayOutputStream();
+    ServletOutputStream sos=new ServletOutputStreamDelegator(bos);
+
+    String contentType;
+    long contentLength;
+
+    public HttpServletResponseAdapter(Request request) {
+        builder.request(request);
+        builder.protocol(Protocol.HTTP_1_1);
+    }
+
+    @Override
+    public void addCookie(Cookie cookie) {
+    }
+
+    @Override
+    public boolean containsHeader(String name) {
+        return false;
+    }
+
+    @Override
+    public String encodeURL(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectURL(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeUrl(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectUrl(String url) {
+        return null;
+    }
+
+    @Override
+    public void sendError(int sc, String msg) throws IOException {
+
+    }
+
+    @Override
+    public void sendError(int sc) throws IOException {
+
+    }
+
+    @Override
+    public void sendRedirect(String location) throws IOException {
+
+    }
+
+    @Override
+    public void setDateHeader(String name, long date) {
+        builder.header(name,String.valueOf(date));
+    }
+
+    @Override
+    public void addDateHeader(String name, long date) {
+        builder.addHeader(name,String.valueOf(date));
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+        builder.header(name,value);
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+        builder.addHeader(name,value);
+    }
+
+    @Override
+    public void setIntHeader(String name, int value) {
+        builder.header(name,String.valueOf(value));
+    }
+
+    @Override
+    public void addIntHeader(String name, int value) {
+        builder.addHeader(name,String.valueOf(value));
+    }
+
+    @Override
+    public void setStatus(int sc) {
+        builder.code(sc).message(String.format("Status %d",sc));
+    }
+
+    @Override
+    public void setStatus(int sc, String sm) {
+        builder.code(sc).message(sm);
+    }
+
+    @Override
+    public int getStatus() {
+        return builder.build().code();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return builder.build().header(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        return builder.build().headers().values(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        return builder.build().headers().names();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        return sos;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        return new PrintWriter(bos);
+    }
+
+    @Override
+    public void setCharacterEncoding(String charset) {
+    }
+
+    @Override
+    public void setContentLength(int len) {
+        contentLength=len;
+    }
+
+    @Override
+    public void setContentLengthLong(long len) {
+        contentLength=len;
+    }
+
+    @Override
+    public void setContentType(String type) {
+        contentType=type;
+    }
+
+    @Override
+    public void setBufferSize(int size) {
+    }
+
+    @Override
+    public int getBufferSize() {
+        return 0;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+    }
+
+    @Override
+    public void resetBuffer() {
+    }
+
+    @Override
+    public boolean isCommitted() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void setLocale(Locale loc) {
+
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    public Response toResponse() {
+        if(contentType!=null) {
+            ResponseBody body= ResponseBody.create(bos.toByteArray(), MediaType.parse(contentType));
+            builder.body(body);
+        }
+        return builder.build();
+    }
+}

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/IJakartaAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/IJakartaAdapter.java
@@ -14,7 +14,7 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
  * An invocation handler which maps all jakarta objects
  * to a javax.servlet level
  */
-public interface IJakartaWrapper<Target> {
+public interface IJakartaAdapter<Target> {
 
     /**
      * @return the wrapper object
@@ -31,21 +31,21 @@ public interface IJakartaWrapper<Target> {
      * @param types array of type annotations
      * @param args array of objects
      * @return unwrapped array of objects
-     * @throws Throwable
+     * @throws Throwable in case something strange happens
      */
     static Object[] unwrap(Class[] types, Object[] args) throws Throwable {
         if(args==null) args=new Object[0];
         for(int count=0;count<args.length;count++) {
             if(types[count].getCanonicalName().startsWith("javax.servlet") && args[count]!=null) {
-                IJakartaWrapper<Object> wrapper=null;
-                if(args[count] instanceof IJakartaWrapper) {
-                    wrapper=(IJakartaWrapper<Object>) args[count];
+                IJakartaAdapter<Object> wrapper;
+                if(args[count] instanceof IJakartaAdapter) {
+                    wrapper=(IJakartaAdapter<Object>) args[count];
                 } else {
                     // we assume its a proxy
-                    wrapper=(IJakartaWrapper<Object>) Proxy.getInvocationHandler(args[count]);
+                    wrapper=(IJakartaAdapter<Object>) Proxy.getInvocationHandler(args[count]);
                 }
                 args[count]=wrapper.getDelegate();
-                Class jakartaClass=IJakartaWrapper.class.getClassLoader().loadClass(types[count].getCanonicalName().replace("javax.servlet","jakarta.servlet"));
+                Class jakartaClass= IJakartaAdapter.class.getClassLoader().loadClass(types[count].getCanonicalName().replace("javax.servlet","jakarta.servlet"));
                 types[count]=jakartaClass;
             }
         }
@@ -62,14 +62,14 @@ public interface IJakartaWrapper<Target> {
      */
     static <Target> Target javaxify(Object jakarta, Class<Target> javaxClass, Monitor monitor) {
         if(javax.servlet.ServletInputStream.class.equals(javaxClass)) {
-            return (Target) new JakartaServletInputStreamWrapper((jakarta.servlet.ServletInputStream) jakarta,monitor);
+            return (Target) new JakartaServletInputStreamAdapter((jakarta.servlet.ServletInputStream) jakarta,monitor);
         }
         if(javax.servlet.ServletOutputStream.class.equals(javaxClass)) {
-            return (Target) new JakartaServletOutputStreamWrapper((jakarta.servlet.ServletOutputStream) jakarta,monitor);
+            return (Target) new JakartaServletOutputStreamAdapter((jakarta.servlet.ServletOutputStream) jakarta,monitor);
         }
-        return (Target) Proxy.newProxyInstance(JakartaWrapper.class.getClassLoader(),
+        return (Target) Proxy.newProxyInstance(JakartaAdapter.class.getClassLoader(),
             new Class[] { javaxClass },
-            new JakartaWrapper(jakarta,monitor));
+            new JakartaAdapter(jakarta,monitor));
     }
 
 }

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/JakartaAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/JakartaAdapter.java
@@ -14,12 +14,12 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
  * An invocation handler which maps all jakarta objects
  * to a javax.servlet level
  */
-public class JakartaWrapper implements InvocationHandler, IJakartaWrapper<Object> {
+public class JakartaAdapter implements InvocationHandler, IJakartaAdapter<Object> {
     
     Object jakartaDelegate;
     Monitor monitor;
 
-    public JakartaWrapper(Object jakartaDelegate, Monitor monitor) {
+    public JakartaAdapter(Object jakartaDelegate, Monitor monitor) {
         this.jakartaDelegate=jakartaDelegate;
         this.monitor=monitor;
     }
@@ -37,12 +37,12 @@ public class JakartaWrapper implements InvocationHandler, IJakartaWrapper<Object
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         Class[] types=method.getParameterTypes();
-        args=IJakartaWrapper.unwrap(types,args);
+        args= IJakartaAdapter.unwrap(types,args);
         Method targetMethod=jakartaDelegate.getClass().getMethod(method.getName(),types);
         Object result=targetMethod.invoke(jakartaDelegate,args);
         //monitor.debug(String.format("Jakarta wrapper mapped method %s to target method %s on args %s with result %s",method,targetMethod,Arrays.toString(args),result));
         if((!method.getReturnType().isAssignableFrom(targetMethod.getReturnType())) && result!=null) {
-            result=IJakartaWrapper.javaxify(result,method.getReturnType(),monitor);
+            result= IJakartaAdapter.javaxify(result,method.getReturnType(),monitor);
         }
         return result;
     }

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/JakartaServletInputStreamAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/JakartaServletInputStreamAdapter.java
@@ -10,18 +10,19 @@ import java.io.IOException;
 
 import javax.servlet.ReadListener;
 
+import jakarta.servlet.ServletInputStream;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 
 /**
  * An invocation handler which maps all jakarta input stream
  * to a javax.servlet level
  */
-public class JakartaServletInputStreamWrapper extends javax.servlet.ServletInputStream implements IJakartaWrapper<jakarta.servlet.ServletInputStream> {
+public class JakartaServletInputStreamAdapter extends javax.servlet.ServletInputStream implements IJakartaAdapter<ServletInputStream> {
     
     jakarta.servlet.ServletInputStream jakartaDelegate;
     Monitor monitor;
 
-    public JakartaServletInputStreamWrapper(jakarta.servlet.ServletInputStream jakartaDelegate, Monitor monitor) {
+    public JakartaServletInputStreamAdapter(jakarta.servlet.ServletInputStream jakartaDelegate, Monitor monitor) {
         this.jakartaDelegate=jakartaDelegate;
         this.monitor=monitor;
     }

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/JakartaServletOutputStreamAdapter.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/JakartaServletOutputStreamAdapter.java
@@ -10,18 +10,19 @@ import java.io.IOException;
 
 import javax.servlet.WriteListener;
 
+import jakarta.servlet.ServletOutputStream;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 
 /**
  * An invocation handler which maps jakarta output stream
  * to a javax.servlet level
  */
-public class JakartaServletOutputStreamWrapper extends javax.servlet.ServletOutputStream implements IJakartaWrapper<jakarta.servlet.ServletOutputStream> {
+public class JakartaServletOutputStreamAdapter extends javax.servlet.ServletOutputStream implements IJakartaAdapter<ServletOutputStream> {
     
     jakarta.servlet.ServletOutputStream jakartaDelegate;
     Monitor monitor;
 
-    public JakartaServletOutputStreamWrapper(jakarta.servlet.ServletOutputStream jakartaDelegate, Monitor monitor) {
+    public JakartaServletOutputStreamAdapter(jakarta.servlet.ServletOutputStream jakartaDelegate, Monitor monitor) {
         this.jakartaDelegate=jakartaDelegate;
         this.monitor=monitor;
     }

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/ServletInputStreamDelegator.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/ServletInputStreamDelegator.java
@@ -1,0 +1,76 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package io.catenax.knowledge.dataspace.edc.http;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Delegating servlet input stream into a simple input stream
+ */
+public class ServletInputStreamDelegator extends ServletInputStream {
+
+    private final InputStream sourceStream;
+
+    private boolean finished = false;
+
+
+    /**
+     * Create a DelegatingServletInputStream for the given source stream.
+     * @param sourceStream the source stream (never {@code null})
+     */
+    public ServletInputStreamDelegator(InputStream sourceStream) {
+        this.sourceStream = sourceStream;
+    }
+
+    /**
+     * Return the underlying source stream (never {@code null}).
+     * @return input stream
+     */
+    public final InputStream getSourceStream() {
+        return this.sourceStream;
+    }
+
+
+    @Override
+    public int read() throws IOException {
+        int data = this.sourceStream.read();
+        if (data == -1) {
+            this.finished = true;
+        }
+        return data;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return this.sourceStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        this.sourceStream.close();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return this.finished;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/ServletOutputStreamDelegator.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/http/ServletOutputStreamDelegator.java
@@ -1,0 +1,49 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package io.catenax.knowledge.dataspace.edc.http;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * delegates a servlet output stream to a simple outputstream
+ */
+public class ServletOutputStreamDelegator extends ServletOutputStream {
+
+    final OutputStream delegate;
+
+    public ServletOutputStreamDelegator(OutputStream delegate) {
+           this.delegate=delegate;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        delegate.write(b, off, len);
+    }
+
+}

--- a/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/sparql/DataspaceServiceExecutor.java
+++ b/dataspace/edc/agentplane-azurevault/src/main/java/io/catenax/knowledge/dataspace/edc/sparql/DataspaceServiceExecutor.java
@@ -8,22 +8,22 @@ package io.catenax.knowledge.dataspace.edc.sparql;
 
 import io.catenax.knowledge.dataspace.edc.AgentConfig;
 import io.catenax.knowledge.dataspace.edc.AgreementController;
-import io.catenax.knowledge.dataspace.edc.http.HttpClientWrapper;
+import io.catenax.knowledge.dataspace.edc.http.HttpClientAdapter;
 import jakarta.ws.rs.WebApplicationException;
 import okhttp3.OkHttpClient;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.http.HttpEnv;
-import org.apache.jena.http.RegistryHttpClient;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecException;
-import org.apache.jena.query.QueryFactory;
 import org.apache.jena.riot.out.NodeFmtLib;
 import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.algebra.OpAsQuery;
 import org.apache.jena.sparql.algebra.OpVars;
+import org.apache.jena.sparql.algebra.op.Op1;
+import org.apache.jena.sparql.algebra.op.Op2;
+import org.apache.jena.sparql.algebra.op.OpGraph;
 import org.apache.jena.sparql.algebra.op.OpService;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
@@ -38,8 +38,6 @@ import org.apache.jena.sparql.engine.iterator.QueryIterSingleton;
 import org.apache.jena.sparql.exec.RowSet;
 import org.apache.jena.sparql.exec.http.*;
 import org.apache.jena.sparql.service.single.ServiceExecutorHttp;
-import org.apache.jena.sparql.syntax.Element;
-import org.apache.jena.sparql.syntax.ElementSubQuery;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.Symbol;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -72,6 +70,8 @@ public class DataspaceServiceExecutor extends ServiceExecutorHttp {
     public final static Symbol authKey = Symbol.create("cx:authKey");
     public final static Symbol authSecret = Symbol.create("cx:authSecret");
     public final static Pattern EDC_TARGET_ADDRESS = Pattern.compile("(?<protocol>edc|edcs)://(?<connector>[^#?]*)(#(?<asset>[^/?]*))?(\\?(?<params>.*))?");
+    public final static Symbol targetUrl = Symbol.create("cx:targetUrl");
+    public final static Symbol asset = Symbol.create("cx:asset");
 
     /**
      * create a new executor
@@ -83,9 +83,39 @@ public class DataspaceServiceExecutor extends ServiceExecutorHttp {
         this.monitor = monitor;
         this.agreementController = controller;
         this.config = config;
-        this.client=new HttpClientWrapper(client);
+        this.client=new HttpClientAdapter(client);
     }
 
+    /**
+     * derive unique asset name from embedded graph operators
+     * @param operator embedding operator
+     * @return unique graph asset found, null if there is none
+     */
+    protected String getUniqueGraph(Op operator) {
+        if(operator instanceof OpGraph) {
+            Node graphNode = ((OpGraph) operator).getNode();
+            if(!graphNode.isURI()) {
+                throw new QueryExecException(String.format("Could not derive asset name from graph operator %s which is not an uri.",operator));
+            } else {
+                return graphNode.getURI();
+            }
+        } else if(operator instanceof Op2) {
+            String asset=getUniqueGraph(((Op2) operator).getLeft());
+            String asset2=getUniqueGraph(((Op2) operator).getRight());
+            if(asset!=null) {
+                if(asset2!=null) {
+                    if(!(asset.equals(asset2))) {
+                        throw new QueryExecException(String.format("Only a single graph asset is allowed in EDC-Protocol Services. Found %s and %s.", asset, asset2));
+                    }
+                }
+                return asset;
+            }
+            return asset2;
+        } else if(operator instanceof Op1) {
+            return getUniqueGraph(((Op1) operator).getSubOp());
+        }
+        return null;
+    }
 
     /**
      * (re-) implements the http service execution
@@ -125,7 +155,10 @@ public class DataspaceServiceExecutor extends ServiceExecutorHttp {
             }
             String asset = edcMatcher.group("asset");
             if (asset == null || asset.length() == 0) {
-                asset = config.getDefaultAsset();
+                asset=getUniqueGraph(opExecute);
+                if(asset==null) {
+                    throw new QueryExecException("There is no graph asset under service: " + target);
+                }
             }
             EndpointDataReference endpoint = agreementController.get(asset);
             if (endpoint == null) {
@@ -151,7 +184,7 @@ public class DataspaceServiceExecutor extends ServiceExecutorHttp {
                 context.put(Service.serviceParams, allServiceParams);
             }
             Map<String, List<String>> serviceParams = allServiceParams.computeIfAbsent(targetUrl, k -> new HashMap<>());
-            serviceParams.put("Accept",List.of("application/json"));
+            serviceParams.put("cx_accept",List.of("application/json"));
             realOpExecute = new OpService(newServiceNode, opExecute.getSubOp(), opExecute.getServiceElement(), silent);
             execCxt.getContext().put(authKey, endpoint.getAuthKey());
             execCxt.getContext().put(authSecret, endpoint.getAuthCode());
@@ -231,15 +264,15 @@ public class DataspaceServiceExecutor extends ServiceExecutorHttp {
                 qExecBuilder.httpHeader(context.get(authKey), context.get(authSecret));
             }
 
-            QueryExecHTTP qExec = qExecBuilder.build();
-
-            // Detach from the network stream.
-            RowSet rowSet = qExec.select().materialize();
-            QueryIterator qIter = QueryIterPlainWrapper.create(rowSet);
-            if (requiresRemapping)
-                qIter = QueryIter.map(qIter, varMapping);
-            qIter = QueryIter.makeTracked(qIter, execCxt);
-            return new QueryIterCommonParent(qIter, binding, execCxt);
+            try(QueryExecHTTP qExec = qExecBuilder.build()) {
+                // Detach from the network stream.
+                RowSet rowSet = qExec.select().materialize();
+                QueryIterator qIter = QueryIterPlainWrapper.create(rowSet);
+                if (requiresRemapping)
+                    qIter = QueryIter.map(qIter, varMapping);
+                qIter = QueryIter.makeTracked(qIter, execCxt);
+                return new QueryIterCommonParent(qIter, binding, execCxt);
+            }
         } catch (RuntimeException ex) {
             if (silent) {
                 Log.warn(this, "SERVICE " + NodeFmtLib.strTTL(opExecute.getService()) + " : " + ex.getMessage());

--- a/dataspace/edc/agentplane-azurevault/src/test/java/io/catenax/knowledge/dataspace/edc/http/TestAgentController.java
+++ b/dataspace/edc/agentplane-azurevault/src/test/java/io/catenax/knowledge/dataspace/edc/http/TestAgentController.java
@@ -7,19 +7,18 @@
 package io.catenax.knowledge.dataspace.edc.http;
 
 import io.catenax.knowledge.dataspace.edc.AgentConfig;
+import io.catenax.knowledge.dataspace.edc.SkillStore;
 import io.catenax.knowledge.dataspace.edc.TestConfig;
 import io.catenax.knowledge.dataspace.edc.sparql.DataspaceServiceExecutor;
 import io.catenax.knowledge.dataspace.edc.sparql.SparqlQueryProcessor;
-import okhttp3.OkHttpClient;
+import okhttp3.*;
 import org.apache.jena.sparql.service.ServiceExecutorRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
@@ -60,7 +59,8 @@ public class TestAgentController {
     OkHttpClient client=new OkHttpClient();
     DataspaceServiceExecutor exec=new DataspaceServiceExecutor(monitor,null,agentConfig,client);
     SparqlQueryProcessor processor=new SparqlQueryProcessor(reg,monitor,agentConfig);
-    AgentController agentController=new AgentController(monitor,null,agentConfig,null,processor);
+    SkillStore skillStore=new SkillStore();
+    AgentController agentController=new AgentController(monitor,null,agentConfig,null,processor,skillStore);
 
     AutoCloseable mocks=null;
 
@@ -336,6 +336,24 @@ public class TestAgentController {
         agentController.postSkill(query,asset);
         String result=testExecute("GET",null,asset,"*/*",List.of(new AbstractMap.SimpleEntry<>("input","84")));
         JsonNode root=mapper.readTree(result);
+        JsonNode whatBinding0=root.get("results").get("bindings").get(0).get("what");
+        assertEquals("84",whatBinding0.get("value").asText(),"Correct binding");
+    }
+
+    /**
+     * test federation call - will only work with a local oem provider running
+     * @throws IOException in case of an error
+     */
+    @Test
+    @Tag("online")
+    public void testFederatedSkill2() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?what WHERE { SERVICE<edc://localhost:8080/sparql> { " +
+                "GRAPH <urn:cx:Graph:4711> { VALUES (?what) { (\"42\"^^xsd:int)} } } }";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        Response response=processor.execute(builder.build(),null,null);
+        JsonNode root=mapper.readTree(response.body().string());
         JsonNode whatBinding0=root.get("results").get("bindings").get(0).get("what");
         assertEquals("84",whatBinding0.get("value").asText(),"Correct binding");
     }

--- a/infrastructure/consumer/resources/dataplane.properties
+++ b/infrastructure/consumer/resources/dataplane.properties
@@ -14,6 +14,7 @@ edc.api.control.auth.apikey.key=X-Api-Key
 edc.api.control.auth.apikey.value=foo
 
 cx.agent.controlplane.url=http://oem-control-plane:8181/data
+cx.agent.asset.file=dataspace.ttl
 
     # edc.api.control.auth.apikey.key=
     # edc.api.control.auth.apikey.value=

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -125,10 +125,11 @@ services:
     image: ghcr.io/catenax-ng/product-knowledge/dataspace/agentplane-azure-vault:0.5.4-SNAPSHOT
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     ports:
-      - "8082:8082" # API/sparql endpoint
-      - "8185:8185" # PUBLIC
-      - "8186:8186" # AGREEMENT CALLBACK
+      - "8082:8082"  # API/sparql endpoint
+      - "8185:8185"  # PUBLIC
+      - "8186:8186"  # AGREEMENT CALLBACK
       - "10000:9999" # CONTROL
+      - "8092:8090"  # DEBUG
     environment:
       # If you want to enable multiple endpoints, simply list them with spaces, like ONTOP_PORT: 8080 8082
       EDC_FS_CONFIG: /app/configuration.properties      
@@ -136,5 +137,6 @@ services:
       #JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8090
     volumes:
       - ./consumer/resources/dataplane.properties:/app/configuration.properties
+      - ./resources/dataspace.ttl:/app/dataspace.ttl
       - ./resources/opentelemetry.properties:/app/opentelemetry.properties
       - ./resources/logging.properties:/app/logging.properties

--- a/infrastructure/oem/resources/auth
+++ b/infrastructure/oem/resources/auth
@@ -1,1 +1,1 @@
-foo:$apr1$A01V9YLZ$khlOcHJ0Tl/vrAXYT0D6Q0
+foo:$apr1$nIhJ3NLR$p0LpyDys76h0YKRMokcci/

--- a/infrastructure/resources/dataspace.ttl
+++ b/infrastructure/resources/dataspace.ttl
@@ -40,7 +40,7 @@
                                             cx-telematics:latestMileageReceived "{ \"Value\": 82563, \"Unit\": \"km\" }"^^xsd:string;
                                             cx-telematics:latestDetailReceived <urn:cx:LoadCollective#20000ZP92013LAABW>.
 
-<urn:cx:LoadCollective#20000ZP92013LAABW> cx-diag:hasPartType "oil pressure"^^xsd:string;
+<urn:cx:LoadCollective#20000ZP92013LAABW> cx-diag:hasPartType "clutch"^^xsd:string;
                                           cx-diag:hasLoadSpectrum "{ \"Temp_Oil-class\": [2, 3, 4, 6, 7, 8, 12, 18, 20, 22, 23, 25, 28, 29, 31, 32, 33, 34, 36, 37, 38, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51],  \"Counts\": [1.234E+01, 2.345E+02, 1.654E+02, 4.321E+01, 6.098E+01, 3.432E+02, 1.873E+02, 4.738E+01, 6.927E+01, 1.234E+01, 2.345E+02, 1.654E+02, 2.983E+01, 2.983E+01, 4.321E+01, 3.876E+02, 5.567E+01, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+01, 3.876E+02, 5.567E+01, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+01, 6.098E+01, 3.432E+02, 1.873E+02, 4.738E+01, 6.927E+01] }"^^xsd:string.
 
 <urn:cx:AnonymousVehicle#30000ZP92013LAABW> cx:isAnonymousVehicle "WBAAL31029PZ00003"^^xsd:string;
@@ -57,7 +57,7 @@
                                         cx:hasName "\"Gear Box\""^^xsd:string.
 
 <urn:cx:AnonymousSerializedPart#GB4712> cx:isComponentOf <urn:cx:AnonymousVehicle#20000ZP92013LAABW>;
-                                        cx:hasPartType "oil pressure"^^xsd:string;
+                                        cx:hasPartType "clutch"^^xsd:string;
                                         cx:hasSupplier <urn:cx:BusinessPartner:tiera>;
                                         cx:hasName "\"Gear Oil\""^^xsd:string.
 
@@ -65,3 +65,12 @@
                                         cx:hasPartType "wiring harness"^^xsd:string;
                                         cx:hasSupplier <urn:cx:BusinessPartner:tiera>;
                                         cx:hasName "\"Wiring Harness\""^^xsd:string.
+
+<urn:cx:LoadCollective#30000ZP92013LAABW> cx-telematics:hasFile "{  \"Type\": \"ZF_load_collective\", \"Version\": \"1.7\"  }"^^xsd:string;
+                                          cx-telematics:hasHeader "{  \"CountingMethod\": \"ZF_TimeAtLevel\",    \"CountingUnit\": \"s\",    \"Channels\": [      {        \"Name\": \"Temp_Oil\",        \"Type\": \"Load\",        \"Unit\": \"degC\",        \"LowerLimit\": -40,        \"UpperLimit\": 220,        \"NumberOfBins\": 52      }  ]  }"^^xsd:string.
+
+<urn:cx:LoadCollective#20000ZP92013LAABW> cx-telematics:hasFile "{  \"Type\": \"ZF_load_collective\", \"Version\": \"1.7\"  }"^^xsd:string;
+                                          cx-telematics:hasHeader "{  \"CountingMethod\": \"ZF_TimeAtLevel\",    \"CountingUnit\": \"s\",    \"Channels\": [      {        \"Name\": \"Temp_Oil\",        \"Type\": \"Load\",        \"Unit\": \"degC\",        \"LowerLimit\": -40,        \"UpperLimit\": 220,        \"NumberOfBins\": 52      }  ]  }"^^xsd:string.
+
+<urn:cx:LoadCollective#10000ZP92013LAABW> cx-telematics:hasFile "{  \"Type\": \"ZF_load_collective\", \"Version\": \"1.7\"  }"^^xsd:string;
+                                          cx-telematics:hasHeader "{  \"CountingMethod\": \"ZF_TimeAtLevel\",    \"CountingUnit\": \"s\",    \"Channels\": [      {        \"Name\": \"Temp_Oil\",        \"Type\": \"Load\",        \"Unit\": \"degC\",        \"LowerLimit\": -40,        \"UpperLimit\": 220,        \"NumberOfBins\": 52      }  ]  }"^^xsd:string.

--- a/infrastructure/resources/dataspace.ttl
+++ b/infrastructure/resources/dataspace.ttl
@@ -1,0 +1,67 @@
+#################################################################
+# Catena-X Agent Bootstrap in TTL/RDF/OWL FORMAT
+# See copyright notice in the top folder
+# See authors file in the top folder
+# See license file in the top folder
+#################################################################
+
+@prefix : <urn:cx:Graph:local:Dataspace> .
+@prefix cx: <https://github.com/catenax-ng/product-knowledge/ontology/cx.ttl#> .
+@prefix cx-diag: <https://github.com/catenax-ng/product-knowledge/ontology/diagnosis.ttl#> .
+@prefix cx-telematics: <https://github.com/catenax-ng/product-knowledge/ontology/telematics.ttl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <urn:cx:Graph:local:Dataspace> .
+
+<urn:cx:BusinessPartner:oem> cx:hasLongBusinessPartnerNumber "BPNL00000003COJN"^^xsd:string;
+                             cx:isIssuerOfVehicleIdentificationNumber "WBAAL31029PZ00001"^^xsd:string;
+                             cx:isIssuerOfVehicleIdentificationNumber "WBAAL31029PZ00002"^^xsd:string;
+                             cx:isIssuerOfVehicleIdentificationNumber "WBAAL31029PZ00003"^^xsd:string;
+                             cx:hasConnector <edc://oem-control-plane:8282>;
+                             cx:offersAsset <urn:cx:Graph:oem:Diagnosis2022>.
+
+<urn:cx:BusinessPartner:tiera> cx:hasLongBusinessPartnerNumber "BPNL00000003CPIY"^^xsd:string;
+                               cx:hasConnector <edc://oem-control-plane:8282>;
+                               cx:offersAsset <urn:cx:Graph:tierA:LifetimeGearbox>.
+
+<urn:cx:AnonymousVehicle#10000ZP92013LAABW> cx:isAnonymousVehicle "WBAAL31029PZ00001"^^xsd:string;
+                                            cx:hasRegistration "{ \"Value\": 20220624,  \"Unit\": \"yyyymmdd\" }"^^xsd:string;
+                                            cx-telematics:latestMileageReceived "{ \"Value\": 6017, \"Unit\": \"km\" }"^^xsd:string;
+                                            cx-telematics:latestDetailReceived <urn:cx:LoadCollective#10000ZP92013LAABW>.
+
+<urn:cx:LoadCollective#10000ZP92013LAABW> cx-diag:hasPartType "engine control module"^^xsd:string;
+                                          cx-diag:hasLoadSpectrum "{ \"Temp_Oil-class\": [1, 3, 4, 5, 7, 8, 12, 13, 17, 18, 20, 22, 23, 25, 28, 29, 31, 32, 33, 34, 36, 37, 38, 41, 42, 44, 45, 47, 48, 49, 50, 51],  \"Counts\": [7.234E+01, 2.345E+02, 6.654E+02, 5.983E+01, 4.321E+02, 3.876E+02, 5.567E+01, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+02, 6.098E+02, 7.432E+02, 8.873E+02, 4.738E+01, 6.927E+01, 1.234E+02, 2.345E+02, 3.654E+02, 2.983E+01, 4.321E+01, 3.876E+02, 5.567E+02, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+01, 6.098E+01, 3.432E+02, 1.873E+02, 4.738E+02, 6.927E+02] }"^^xsd:string.
+
+<urn:cx:AnonymousVehicle#20000ZP92013LAABW> cx:isAnonymousVehicle "WBAAL31029PZ00002"^^xsd:string;
+                                            cx:hasRegistration "{ \"Value\": 20171206,  \"Unit\": \"yyyymmdd\" }"^^xsd:string;
+                                            cx-telematics:latestMileageReceived "{ \"Value\": 82563, \"Unit\": \"km\" }"^^xsd:string;
+                                            cx-telematics:latestDetailReceived <urn:cx:LoadCollective#20000ZP92013LAABW>.
+
+<urn:cx:LoadCollective#20000ZP92013LAABW> cx-diag:hasPartType "oil pressure"^^xsd:string;
+                                          cx-diag:hasLoadSpectrum "{ \"Temp_Oil-class\": [2, 3, 4, 6, 7, 8, 12, 18, 20, 22, 23, 25, 28, 29, 31, 32, 33, 34, 36, 37, 38, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51],  \"Counts\": [1.234E+01, 2.345E+02, 1.654E+02, 4.321E+01, 6.098E+01, 3.432E+02, 1.873E+02, 4.738E+01, 6.927E+01, 1.234E+01, 2.345E+02, 1.654E+02, 2.983E+01, 2.983E+01, 4.321E+01, 3.876E+02, 5.567E+01, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+01, 3.876E+02, 5.567E+01, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+01, 6.098E+01, 3.432E+02, 1.873E+02, 4.738E+01, 6.927E+01] }"^^xsd:string.
+
+<urn:cx:AnonymousVehicle#30000ZP92013LAABW> cx:isAnonymousVehicle "WBAAL31029PZ00003"^^xsd:string;
+                                            cx:hasRegistration "{ \"Value\": 20130302,  \"Unit\": \"yyyymmdd\" }"^^xsd:string;
+                                            cx-telematics:latestMileageReceived "{ \"Value\": 247332, \"Unit\": \"km\" }"^^xsd:string;
+                                            cx-telematics:latestDetailReceived <urn:cx:LoadCollective#30000ZP92013LAABW>.
+
+<urn:cx:LoadCollective#30000ZP92013LAABW> cx-diag:hasPartType "wiring harness"^^xsd:string;
+                                          cx-diag:hasLoadSpectrum "{ \"Temp_Oil-class\": [1, 3, 4, 5, 7, 8, 12, 13, 17, 18, 20, 22, 23, 25, 28, 29, 31, 32, 33, 34, 36, 37, 38, 41, 42, 44, 45, 47, 48, 49, 50, 51],  \"Counts\": [1.234E+01, 2.345E+02, 1.654E+02, 2.983E+02, 4.321E+01, 3.876E+02, 5.567E+01, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+02, 6.098E+02, 3.432E+02, 1.873E+02, 4.738E+01, 6.927E+01, 8.234E+01, 2.345E+02, 4.654E+02, 2.983E+01, 4.321E+01, 3.876E+02, 9.567E+01, 3.4456E+02, 4.556645E+02, 5.678E+01, 4.321E+02, 6.098E+01, 3.432E+02, 1.873E+02, 4.738E+01, 5.927E+01] }"^^xsd:string.
+
+<urn:cx:AnonymousSerializedPart#GB4711> cx:isComponentOf <urn:cx:AnonymousVehicle#10000ZP92013LAABW>;
+                                        cx:hasPartType "engine control module"^^xsd:string;
+                                        cx:hasSupplier <urn:cx:BusinessPartner:tiera>;
+                                        cx:hasName "\"Gear Box\""^^xsd:string.
+
+<urn:cx:AnonymousSerializedPart#GB4712> cx:isComponentOf <urn:cx:AnonymousVehicle#20000ZP92013LAABW>;
+                                        cx:hasPartType "oil pressure"^^xsd:string;
+                                        cx:hasSupplier <urn:cx:BusinessPartner:tiera>;
+                                        cx:hasName "\"Gear Oil\""^^xsd:string.
+
+<urn:cx:AnonymousSerializedPart#GB4713> cx:isComponentOf <urn:cx:AnonymousVehicle#30000ZP92013LAABW>;
+                                        cx:hasPartType "wiring harness"^^xsd:string;
+                                        cx:hasSupplier <urn:cx:BusinessPartner:tiera>;
+                                        cx:hasName "\"Wiring Harness\""^^xsd:string.

--- a/infrastructure/templates/consumer-connector.yaml
+++ b/infrastructure/templates/consumer-connector.yaml
@@ -21,6 +21,8 @@ data:
     edc.api.control.auth.apikey.value={{ .Values.security.xApiKey }}
     
     cx.agent.controlplane.url=http://oem-control-plane:8181/data
+    cx.agent.asset.file=dataspace.ttl
+
         # edc.api.control.auth.apikey.key=
         # edc.api.control.auth.apikey.value=
         # edc.assetindex.cosmos.account-name=
@@ -155,7 +157,7 @@ data:
   agent.ttl: |-
 {{- .Files.Get "consumer/resources/agent.ttl" | nindent 4 }}
   dataspace.ttl: |-
-{{- .Files.Get "consumer/resources/dataspace.ttl" | nindent 4 }}
+{{- .Files.Get "resources/dataspace.ttl" | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
by a proper AgentSource. Refactoring out the skill store capability. Take Asset Names out of Graph nodes on the consumer-side and manipulate the Graph nodes into Service nodes on the provider side.